### PR TITLE
*Correctly* support JSON objects

### DIFF
--- a/include/SIOClient.h
+++ b/include/SIOClient.h
@@ -31,6 +31,7 @@ public:
 	void disconnect();
 	void send(std::string s);
 	void emit(std::string eventname, std::string args);
+	void emit(std::string eventname, Poco::JSON::Object::Ptr json_data);
 	std::string getUri();
 	Poco::NotificationCenter* getNCenter();
 

--- a/include/SIOClientImpl.h
+++ b/include/SIOClientImpl.h
@@ -50,6 +50,7 @@ public:
 	void send(std::string endpoint, std::string s);
 	void send(SocketIOPacket *packet);
 	void emit(std::string endpoint, std::string eventname, std::string args);
+	void emit(std::string endpoint, std::string eventname, Poco::JSON::Object::Ptr json_data);
 
 	std::string getUri();
 

--- a/include/SIOPacket.h
+++ b/include/SIOPacket.h
@@ -34,6 +34,7 @@ public:
 	std::string getEvent(){return _name;};
 
 	void addData(std::string data);
+	void addJSONData(Poco::JSON::Object::Ptr json_data);
 	void addData(Poco::JSON::Array::Ptr data);
 	Poco::JSON::Array getDatas(){return _args;};
 	virtual std::string stringify();

--- a/src/SIOClient.cpp
+++ b/src/SIOClient.cpp
@@ -1,6 +1,7 @@
 #include "SIOClient.h"
 #include "SIOClientRegistry.h"
 
+#include "Poco/Foundation.h"
 #include "Poco/URI.h"
 
 using Poco::URI;
@@ -100,4 +101,9 @@ void SIOClient::send(std::string s)
 void SIOClient::emit(std::string eventname, std::string args)
 {
 	_socket->emit(_endpoint, eventname, args);
+}
+
+void SIOClient::emit(std::string eventname, Poco::JSON::Object::Ptr json_data)
+{
+	_socket->emit(_endpoint, eventname, json_data);
 }

--- a/src/SIOClientImpl.cpp
+++ b/src/SIOClientImpl.cpp
@@ -346,6 +346,17 @@ void SIOClientImpl::send(std::string endpoint, std::string s)
 	}
 }
 
+void SIOClientImpl::emit(std::string endpoint, std::string eventname, Poco::JSON::Object::Ptr json_data)
+{
+	_logger->information("Emitting event \"%s\"",eventname);
+	SocketIOPacket *packet = SocketIOPacket::createPacketWithType("event",_version);
+	packet->setEndpoint(endpoint);
+	packet->setEvent(eventname);
+	packet->addJSONData(json_data);
+	this->send(packet);
+}
+
+
 void SIOClientImpl::emit(std::string endpoint, std::string eventname, std::string args)
 {
 	_logger->information("Emitting event \"%s\"",eventname);

--- a/src/SIOPacket.cpp
+++ b/src/SIOPacket.cpp
@@ -78,6 +78,9 @@ std::string SocketIOPacket::toString()
 		}
 		encoded << ackpId << this->stringify();
 	}
+
+	std::cout << "Encoded String: " << encoded.str() << std::endl;
+
 	return encoded.str();
 }
 int SocketIOPacket::typeAsNumber()
@@ -93,6 +96,11 @@ int SocketIOPacket::typeAsNumber()
 std::string SocketIOPacket::typeForIndex(int index)
 {
 	return _types.at(index);
+}
+
+void SocketIOPacket::addJSONData(Poco::JSON::Object::Ptr json_data)
+{
+	this->_args.add(json_data);
 }
 
 void SocketIOPacket::addData(std::string data)

--- a/src/SIOPacket.cpp
+++ b/src/SIOPacket.cpp
@@ -78,9 +78,7 @@ std::string SocketIOPacket::toString()
 		}
 		encoded << ackpId << this->stringify();
 	}
-
-	std::cout << "Encoded String: " << encoded.str() << std::endl;
-
+	
 	return encoded.str();
 }
 int SocketIOPacket::typeAsNumber()


### PR DESCRIPTION
Currently, socket.io-poco can only emit string (which is very, very annoying), and as a result, when we were trying to send JSON serializations up, they were getting double escaped. This PR correctly adds JSON object support.